### PR TITLE
Local and remote evaluation random seed consistency

### DIFF
--- a/ddppo_agents.py
+++ b/ddppo_agents.py
@@ -49,7 +49,7 @@ def set_random_seed(seed: int):
 
 
 def sample_random_seed():
-    set_random_seed(random_generator.randint(2 ** 32))
+    set_random_seed(random_generator.randint(2**32))
 
 
 class PPOAgent(Agent):

--- a/ddppo_agents.py
+++ b/ddppo_agents.py
@@ -34,16 +34,19 @@ from habitat_baselines.utils.common import batch_obs
 
 random_generator = np.random.RandomState()
 
+
 @numba.njit
 def _seed_numba(seed: int):
     random.seed(seed)
     np.random.seed(seed)
+
 
 def set_random_seed(seed: int):
     random.seed(seed)
     np.random.seed(seed)
     _seed_numba(seed)
     torch.random.manual_seed(seed)
+
 
 def sample_random_seed():
     set_random_seed(random_generator.randint(2 ** 32))

--- a/ddppo_agents.py
+++ b/ddppo_agents.py
@@ -31,7 +31,6 @@ from habitat_baselines.config.default import get_config
 from habitat_baselines.rl.ddppo.policy import PointNavResNetPolicy
 from habitat_baselines.utils.common import batch_obs
 
-
 random_generator = np.random.RandomState()
 
 

--- a/ddppo_agents.py
+++ b/ddppo_agents.py
@@ -108,6 +108,7 @@ class PPOAgent(Agent):
             else torch.device("cpu")
         )
         self.hidden_size = config.RL.PPO.hidden_size
+        random_generator.seed(config.RANDOM_SEED)
 
         if torch.cuda.is_available():
             torch.backends.cudnn.deterministic = True  # type: ignore


### PR DESCRIPTION
Made local and remote evaluation random seed consistent with setting separate random number generator and setting random seed with each step.

 On mini-val custom solution with RedNet semantic segmentation.

Local Docker result:
```
SPL: 0.1276936106433208
SOFT_SPL: 0.22182186917517072
DISTANCE_TO_GOAL: 3.317090990394354
SUCCESS: 0.23333333333333334
```

Remote Docker result:
```
SPL': 0.1276936106433208
SOFT_SPL': 0.2218218691751707
DISTANCE_TO_GOAL': 3.317090990394354
SUCCESS': 0.23333333333333334
```