### PR TITLE
Updated Readme: fix data symbolic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ First setup Habitat Sim in a new conda environment so you can download the datas
 
 1. Now, create a symlink to the downloaded data in your habitat-challenge repository:
     ```
-    mkdir -p data
     ln -s <absolute path to download folder> data
     ```
 


### PR DESCRIPTION
Command 
```
    ln -s <absolute path to download folder> data
```
Creates symlink to the downloaded data in habitat-challenge repository: `habitat-challenge/data -> path-to-data/data` (expected).


Command 
```
    mkdir -p data
    ln -s <absolute path to download folder> data
```
Creates symlink `habitat-challenge/data/data -> path-to-data/data`.
